### PR TITLE
PLAT-1214: actually show the error in the configured language

### DIFF
--- a/src/AirMapAuth.js
+++ b/src/AirMapAuth.js
@@ -107,7 +107,7 @@ class AirMapAuth {
                 }
             }
             const authErr = new AuthorizationError(err.error_description.type);
-            this._showAuthError(authErr.getText());
+            this._showAuthError(authErr.getText(this.opts.language));
             this.opts.onAuthorizationError(error);
         });
         // Attaching event listener for DOM load when autoLaunch is desired so that an authenticated check is made.


### PR DESCRIPTION
It seems that mocking Auth0Lock is a bit hard so didn’t write tests :(