### PR TITLE
fix: update jsonwebtoken due to security reasons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -981,11 +981,6 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
       "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w=="
     },
-    "base64url": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
-      "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
-    },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
@@ -2926,11 +2921,10 @@
       }
     },
     "ecdsa-sig-formatter": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
-      "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
+      "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
       "requires": {
-        "base64url": "2.0.0",
         "safe-buffer": "5.1.1"
       }
     },
@@ -5117,11 +5111,6 @@
         "minimalistic-crypto-utils": "1.0.1"
       }
     },
-    "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -5689,11 +5678,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
-    "isemail": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
-      "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo="
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -5722,17 +5706,6 @@
       "dev": true,
       "requires": {
         "ap": "0.1.0"
-      }
-    },
-    "joi": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
-      "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
-      "requires": {
-        "hoek": "2.16.3",
-        "isemail": "1.2.0",
-        "moment": "2.21.0",
-        "topo": "1.1.0"
       }
     },
     "js-tokens": {
@@ -6120,15 +6093,27 @@
       "dev": true
     },
     "jsonwebtoken": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz",
-      "integrity": "sha1-d/UCHeBYtgWheD+hKD6ZgS5kVjg=",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.1.tgz",
+      "integrity": "sha512-l8rUBr0fqYYwPc8/ZGrue7GiW7vWdZtZqelxo4Sd5lMvuEeCK8/wS54sEo6tJhdZ6hqfutsj6COgC0d1XdbHGw==",
       "requires": {
-        "joi": "6.10.1",
-        "jws": "3.1.4",
+        "jws": "3.1.5",
+        "lodash.includes": "4.3.0",
+        "lodash.isboolean": "3.0.3",
+        "lodash.isinteger": "4.0.4",
+        "lodash.isnumber": "3.0.3",
+        "lodash.isplainobject": "4.0.6",
+        "lodash.isstring": "4.0.1",
         "lodash.once": "4.1.1",
-        "ms": "2.0.0",
+        "ms": "2.1.1",
         "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
       }
     },
     "jsprim": {
@@ -6144,23 +6129,21 @@
       }
     },
     "jwa": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
-      "integrity": "sha1-oFUs4CIHQs1S4VN3SjKQXDDnVuU=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
+      "integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
       "requires": {
-        "base64url": "2.0.0",
         "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.9",
+        "ecdsa-sig-formatter": "1.0.10",
         "safe-buffer": "5.1.1"
       }
     },
     "jws": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
-      "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
+      "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
       "requires": {
-        "base64url": "2.0.0",
-        "jwa": "1.1.5",
+        "jwa": "1.1.6",
         "safe-buffer": "5.1.1"
       }
     },
@@ -6329,6 +6312,11 @@
         "lodash._isiterateecall": "3.0.9"
       }
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -6340,6 +6328,31 @@
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.keys": {
       "version": "3.1.2",
@@ -6783,11 +6796,6 @@
         "through2": "2.0.3",
         "xtend": "4.0.1"
       }
-    },
-    "moment": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
-      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
     },
     "ms": {
       "version": "2.0.0",
@@ -8510,14 +8518,6 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
-    },
-    "topo": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
-      "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
-      "requires": {
-        "hoek": "2.16.3"
-      }
     },
     "tough-cookie": {
       "version": "2.3.4",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "auth0-js": "^9.3.2",
-    "jsonwebtoken": "^7.1.9"
+    "jsonwebtoken": "^8.2.1"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",


### PR DESCRIPTION
fixed Prototype pollution attack, by updating jsonwebtoken

Who can run `npm run release` to update airmap-auth npm package?